### PR TITLE
Change to depend on matplotlib-base

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dopplershift @jrleeman
+* @dopplershift @zbruick

--- a/README.md
+++ b/README.md
@@ -208,5 +208,5 @@ Feedstock Maintainers
 =====================
 
 * [@dopplershift](https://github.com/dopplershift/)
-* [@jrleeman](https://github.com/jrleeman/)
+* [@zbruick](https://github.com/zbruick/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
     script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-    number: 0
+    number: 1
 
 requirements:
   host:
@@ -25,7 +25,7 @@ requirements:
     - python
     - numpy >=1.12
     - scipy >=0.17.0
-    - matplotlib >=2.1.0
+    - matplotlib-base >=2.1.0
     - pint >=0.8
     - pooch >=0.1
     - pyproj >=1.9.4


### PR DESCRIPTION
We don't *require* the GUI, so don't depend on matplotlib, just
matplotlib-base. This change to is allow metpy to install alongside
sharppy on linux. Right now, matplotlib (depends on pyqt) cannot install
next to sharppy (depends on pyside2). This will probably be fine once
qt 5.12 builds of pyqt are available.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
